### PR TITLE
Add hierarchical loading for datasets

### DIFF
--- a/pct.py
+++ b/pct.py
@@ -1,12 +1,20 @@
 import os
+import re
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 
 
-class Data():
-    """ object for holding data, metadata, and analysis
-    """
+class Data:
+    """Object for holding data, metadata, and analysis."""
+
+    def __init__(self):
+        self.path = None
+        self.ext = None
+        # dictionary keyed by experiment name. Each experiment contains
+        #   - info: dataframe of experiment information
+        #   - measurements: dict keyed by measurement number
+        self.experiments = {}
 
 
 
@@ -20,18 +28,75 @@ class Dataloader():
         self.path = path
 
     def load(self, ext='.csv'):
-        """ load data and store in a Data object
+        """Load data organised in a dataset/experiment/measurement/repetition
+        hierarchy.
+
+        Parameters
+        ----------
+        ext : str, optional
+            File extension used for experiment level meta data (default '.csv').
+
+        Returns
+        -------
+        Data
+            Structured data object containing experiment information,
+            measurement summaries and repetition data.
         """
+
         data = Data()
         data.path = self.path
         data.ext = ext
-        data.files = [f for f in os.listdir(self.path) if f.endswith(ext)]
-        data.data = []
-        
-        for file in data.files:
-            file_path = os.path.join(self.path, file)
-            file_data = pd.read_csv(file_path, delimiter=',', skiprows=3)
-            
+
+        # iterate through experiments
+        for experiment in sorted(os.listdir(self.path)):
+            exp_path = os.path.join(self.path, experiment)
+            if not os.path.isdir(exp_path):
+                continue
+
+            # load experiment level csv (meta data)
+            exp_info = None
+            exp_csvs = [f for f in os.listdir(exp_path) if f.endswith(ext)]
+            if exp_csvs:
+                info_path = os.path.join(exp_path, exp_csvs[0])
+                try:
+                    exp_info = pd.read_csv(
+                        info_path, skiprows=3, usecols=["Name", "Correlation Type"]
+                    )
+                except Exception:
+                    exp_info = None
+
+            experiment_dict = {"info": exp_info, "measurements": {}}
+
+            # iterate through measurements in the experiment
+            for measurement in sorted(os.listdir(exp_path)):
+                meas_path = os.path.join(exp_path, measurement)
+                if not os.path.isdir(meas_path):
+                    continue
+
+                # parse measurement number from folder name
+                match = re.search(r"(\d+)", measurement)
+                meas_num = int(match.group(1)) if match else measurement
+
+                # load measurement summary
+                summary_path = os.path.join(meas_path, "Summary.csv")
+                summary_df = pd.read_csv(summary_path) if os.path.exists(summary_path) else None
+
+                measurement_dict = {"summary": summary_df, "repetitions": {}}
+
+                # iterate through repetition folders
+                for repetition in sorted(os.listdir(meas_path)):
+                    rep_path = os.path.join(meas_path, repetition)
+                    if not os.path.isdir(rep_path):
+                        continue
+
+                    ct_path = os.path.join(rep_path, "Count Trace.csv")
+                    if os.path.exists(ct_path):
+                        ct_df = pd.read_csv(ct_path)
+                        measurement_dict["repetitions"][repetition] = ct_df
+
+                experiment_dict["measurements"][meas_num] = measurement_dict
+
+            data.experiments[experiment] = experiment_dict
 
         return data
 


### PR DESCRIPTION
## Summary
- flesh out `Data` and `Dataloader` classes
- implement hierarchical data loading that walks the experiment/measurement/repetition tree
- retain experiment meta info, measurement summaries and repetition count traces

## Testing
- `python -m py_compile pct.py`

------
https://chatgpt.com/codex/tasks/task_e_6867228af21c83209537d05cd1f353a0