### PR TITLE
Add hierarchical CSV dataloader

### DIFF
--- a/dataloader.py
+++ b/dataloader.py
@@ -1,0 +1,77 @@
+import os
+from typing import Any, Dict
+
+import pandas as pd
+
+
+def load_dataset(root_path: str, extension: str = ".csv") -> Dict[str, Dict[str, Any]]:
+    """Load CSV files in a sample/experiment/measurement/repetition hierarchy.
+
+    Parameters
+    ----------
+    root_path : str
+        Directory containing sample folders.
+    extension : str, optional
+        CSV file extension to search for (default ".csv").
+
+    Returns
+    -------
+    dict
+        Nested dictionary mapping sample -> experiment -> measurement -> repetition.
+        Each repetition is loaded as a :class:`pandas.DataFrame` with experiment level
+        data stored under the key ``"info"`` and measurement summaries stored under
+        ``"summary"``.
+    """
+    dataset: Dict[str, Dict[str, Any]] = {}
+
+    for sample in sorted(os.listdir(root_path)):
+        sample_path = os.path.join(root_path, sample)
+        if not os.path.isdir(sample_path):
+            continue
+
+        sample_dict: Dict[str, Any] = {"experiments": {}}
+
+        for experiment in sorted(os.listdir(sample_path)):
+            exp_path = os.path.join(sample_path, experiment)
+            if not os.path.isdir(exp_path):
+                continue
+
+            exp_dict: Dict[str, Any] = {"info": None, "measurements": {}}
+
+            exp_csvs = [f for f in os.listdir(exp_path) if f.endswith(extension)]
+            if exp_csvs:
+                info_path = os.path.join(exp_path, exp_csvs[0])
+                try:
+                    exp_dict["info"] = pd.read_csv(info_path)
+                except Exception:
+                    exp_dict["info"] = None
+
+            for measurement in sorted(os.listdir(exp_path)):
+                meas_path = os.path.join(exp_path, measurement)
+                if not os.path.isdir(meas_path):
+                    continue
+
+                meas_dict: Dict[str, Any] = {"summary": None, "repetitions": {}}
+                summary_path = os.path.join(meas_path, f"Summary{extension}")
+                if os.path.exists(summary_path):
+                    try:
+                        meas_dict["summary"] = pd.read_csv(summary_path)
+                    except Exception:
+                        meas_dict["summary"] = None
+
+                for rep_file in sorted(os.listdir(meas_path)):
+                    if rep_file == f"Summary{extension}" or not rep_file.endswith(extension):
+                        continue
+                    rep_path = os.path.join(meas_path, rep_file)
+                    try:
+                        meas_dict["repetitions"][rep_file] = pd.read_csv(rep_path)
+                    except Exception:
+                        meas_dict["repetitions"][rep_file] = None
+
+                exp_dict["measurements"][measurement] = meas_dict
+
+            sample_dict["experiments"][experiment] = exp_dict
+
+        dataset[sample] = sample_dict
+
+    return dataset


### PR DESCRIPTION
## Summary
- add `load_dataset` function to load CSV data organized in sample/experiment/measurement/repetition hierarchy

## Testing
- `python -m py_compile dataloader.py`


------
https://chatgpt.com/codex/tasks/task_e_68967c5c2b8c832083849c2046897a9e