### PR TITLE
Add sample hierarchy level to dataloader

### DIFF
--- a/pct.py
+++ b/pct.py
@@ -11,10 +11,11 @@ class Data:
     def __init__(self):
         self.path = None
         self.ext = None
-        # dictionary keyed by experiment name. Each experiment contains
-        #   - info: dataframe of experiment information
-        #   - measurements: dict keyed by measurement number
-        self.experiments = {}
+        # dictionary keyed by sample name. Each sample contains
+        #   - experiments: dict keyed by experiment name
+        #       - info: dataframe of experiment information
+        #       - measurements: dict keyed by measurement number
+        self.samples = {}
 
 
 
@@ -39,7 +40,7 @@ class Dataloader():
 
 
     def load(self, ext='.csv', delimiter=','):
-        """Load photon correlation spectroscopy data organised in a dataset/experiment/measurement/repetition
+        """Load photon correlation spectroscopy data organised in a dataset/sample/experiment/measurement/repetition
         hierarchy.
 
         Parameters
@@ -58,56 +59,67 @@ class Dataloader():
         data.path = self.path
         data.ext = ext
 
-        # iterate through experiments
-        for experiment in sorted(os.listdir(self.path)):
-            exp_path = os.path.join(self.path, experiment)
-            if not os.path.isdir(exp_path):
+        # iterate through samples
+        for sample in sorted(os.listdir(self.path)):
+            sample_path = os.path.join(self.path, sample)
+            if not os.path.isdir(sample_path):
                 continue
 
-            # load experiment level csv (meta data)
-            exp_info = None
-            exp_csvs = [f for f in os.listdir(exp_path) if f.endswith(ext)]
-            if exp_csvs:
-                info_path = os.path.join(exp_path, exp_csvs[0])
-                try:
-                    exp_info = pd.read_csv(
-                        info_path, skiprows=3, usecols=["Name", "Correlation Type"]
-                    )
-                except Exception:
-                    exp_info = None
+            sample_dict = {"experiments": {}}
 
-            experiment_dict = {"info": exp_info, "measurements": {}}
-
-            # iterate through measurements in the experiment
-            for measurement in sorted(os.listdir(exp_path)):
-                meas_path = os.path.join(exp_path, measurement)
-                if not os.path.isdir(meas_path):
+            # iterate through experiments within the sample
+            for experiment in sorted(os.listdir(sample_path)):
+                exp_path = os.path.join(sample_path, experiment)
+                if not os.path.isdir(exp_path):
                     continue
 
-                # parse measurement number from folder name
-                match = re.search(r"(\d+)", measurement)
-                meas_num = int(match.group(1)) if match else measurement
-                measurement_dict = {"summary": {}, "repetitions": {}}
+                # load experiment level csv (meta data)
+                exp_info = None
+                exp_csvs = [f for f in os.listdir(exp_path) if f.endswith(ext)]
+                if exp_csvs:
+                    info_path = os.path.join(exp_path, exp_csvs[0])
+                    try:
+                        exp_info = pd.read_csv(
+                            info_path, skiprows=3, usecols=["Name", "Correlation Type"]
+                        )
+                    except Exception:
+                        exp_info = None
 
-                # iterate through repetition folders
-                for repetition in sorted(os.listdir(meas_path)):
-                    if repetition == "Count Trace.csv":
-                        rep_path = os.path.join(meas_path, repetition)
-                        ct_df = pd.read_csv(rep_path, skiprows=2)
-                        measurement_dict["repetitions"][repetition] = ct_df
+                experiment_dict = {"info": exp_info, "measurements": {}}
 
-                    if repetition == "Correlation Function.csv":
-                        rep_path = os.path.join(meas_path, repetition)
-                        ct_df = pd.read_csv(rep_path, skiprows=2)
-                        measurement_dict["repetitions"][repetition] = ct_df
+                # iterate through measurements in the experiment
+                for measurement in sorted(os.listdir(exp_path)):
+                    meas_path = os.path.join(exp_path, measurement)
+                    if not os.path.isdir(meas_path):
+                        continue
 
-                    if repetition == "CORENN Gamma Results.csv":
-                        rep_path = os.path.join(meas_path, repetition)
-                        ct_df = pd.read_csv(rep_path, skiprows=5)
-                        measurement_dict["repetitions"][repetition] = ct_df
-                
-                experiment_dict["measurements"][meas_num] = measurement_dict
-            data.experiments[experiment] = experiment_dict
+                    # parse measurement number from folder name
+                    match = re.search(r"(\d+)", measurement)
+                    meas_num = int(match.group(1)) if match else measurement
+                    measurement_dict = {"summary": {}, "repetitions": {}}
+
+                    # iterate through repetition folders
+                    for repetition in sorted(os.listdir(meas_path)):
+                        if repetition == "Count Trace.csv":
+                            rep_path = os.path.join(meas_path, repetition)
+                            ct_df = pd.read_csv(rep_path, skiprows=2)
+                            measurement_dict["repetitions"][repetition] = ct_df
+
+                        if repetition == "Correlation Function.csv":
+                            rep_path = os.path.join(meas_path, repetition)
+                            ct_df = pd.read_csv(rep_path, skiprows=2)
+                            measurement_dict["repetitions"][repetition] = ct_df
+
+                        if repetition == "CORENN Gamma Results.csv":
+                            rep_path = os.path.join(meas_path, repetition)
+                            ct_df = pd.read_csv(rep_path, skiprows=5)
+                            measurement_dict["repetitions"][repetition] = ct_df
+
+                    experiment_dict["measurements"][meas_num] = measurement_dict
+
+                sample_dict["experiments"][experiment] = experiment_dict
+
+            data.samples[sample] = sample_dict
 
         return data
     


### PR DESCRIPTION
## Summary
- expand `Data` structure to nest experiments under samples
- update dataloader to traverse dataset/sample/experiment/measurement/repetition hierarchy

## Testing
- `python -m py_compile pct.py`


------
https://chatgpt.com/codex/tasks/task_e_68969ad3babc8320be25a6b96e6dfe33